### PR TITLE
Make the package be importable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
     "name": "ilib-tools-common",
     "version": "1.0.0",
-    "main": "./lib/index.js",
     "module": "./src/index.js",
+    "exports": {
+        ".": {
+            "import": "./src/index.js"
+        }
+    },
     "type": "module",
     "description": "Library of common classes and functions for the ilib command-line tools",
     "keywords": [
@@ -52,7 +56,7 @@
         "build:prod": "grunt babel --mode=prod",
         "build:dev": "grunt babel --mode=dev",
         "build:test": "webpack-cli --config webpack-test.config.js",
-        "dist": "npm-run-all doc build:prod build:pkg; npm pack",
+        "dist": "npm-run-all doc build:prod; npm pack",
         "test": "LANG=en_US.UTF8 node test/testSuite.js",
         "debug": "LANG=en_US.UTF8 node --inspect-brk test/testSuite.js",
         "clean": "git clean -f -d src test",


### PR DESCRIPTION
Last changes needed before publishing v1.0.0 to make it possible to import it with `import { ResourceString } from 'ilib-tools-common';`