### PR TITLE
Add compatibility with old loctool classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 ## Release Notes
 
-### v1.0.0
+### v1.0.1
 
 - Introduced some backwards compatibility support so that this library
   can be used with loctool plugins.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ limitations under the License.
 
 ### v1.0.0
 
+- Introduced some backwards compatibility support so that this library
+  can be used with loctool plugins.
+    - added some deprecated methods and accept some deprecated
+      constructor parameters
+
+### v1.0.0
+
 - Initial code copied from loctool 2.18.0:
     - Resource
     - ResourceString

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "module": "./src/index.js",
     "exports": {
         ".": {

--- a/src/ResourceArray.js
+++ b/src/ResourceArray.js
@@ -65,23 +65,25 @@ class ResourceArray extends Resource {
         this.subtype = "string-array";
 
         if (props) {
-            if (props.source) {
-                if (!Array.isArray(props.source)) {
-                    this.source = [props.source];
-                } else if (props.source.length) {
+            const source = props.source || props.sourceArray;
+            if (source) {
+                if (!Array.isArray(source)) {
+                    this.source = [source];
+                } else if (source.length) {
                     // make a deep copy of the array
-                    this.source = props.source.map(item => {
+                    this.source = source.map(item => {
                          // both copies the string and ensures that it is a string type
                          return new String(item).toString();
                     });
                 }
             }
-            if (props.target) {
-                if (!Array.isArray(props.target)) {
-                    this.source = [props.target];
-                } else if (props.target.length) {
+            const target = props.target || props.targetArray;
+            if (target) {
+                if (!Array.isArray(target)) {
+                    this.target = [target];
+                } else if (target.length) {
                     // make a deep copy of the array
-                    this.target = props.target.map(item => {
+                    this.target = target.map(item => {
                          return new String(item).toString();
                     });
                 }
@@ -117,6 +119,28 @@ class ResourceArray extends Resource {
     setTarget(arr) {
         if (!arr || !Array.isArray(arr)) return;
         this.target = arr;
+    }
+
+    /**
+     * Return the array of source strings. This method is here
+     * for backwards compatilibity with the loctool plugins.
+     *
+     * @deprecated Use getSource() instead
+     * @returns {Array.<String>} the array of source strings
+     */
+    getSourceArray() {
+        return this.getSource();
+    }
+
+    /**
+     * Return the array of target strings. This method is here
+     * for backwards compatilibity with the loctool plugins.
+     *
+     * @deprecated Use getTarget() instead
+     * @returns {Array.<String>} the array of target strings
+     */
+    getTargetArray() {
+        return this.getTarget();
     }
 
     /**

--- a/src/ResourcePlural.js
+++ b/src/ResourcePlural.js
@@ -66,16 +66,18 @@ class ResourcePlural extends Resource {
         // deep copy this so that the props can have a different set of
         // plural forms than this instance
         if (props) {
-            if (typeof(props.source) === 'object') {
-                for (let p in props.source) {
-                    this.source[p] = props.source[p];
+            const source = props.source || props.sourceStrings || props.sourcePlurals;
+            if (typeof(source) === 'object') {
+                for (let p in source) {
+                    this.source[p] = source[p];
                 }
             }
 
-            if (typeof(props.target) === 'object') {
+            const target = props.target || props.targetStrings || props.targetPlurals;
+            if (typeof(target) === 'object') {
                 this.target = {};
-                for (let p in props.target) {
-                    this.target[p] = props.target[p];
+                for (let p in target) {
+                    this.target[p] = target[p];
                 }
             }
         }
@@ -92,6 +94,50 @@ class ResourcePlural extends Resource {
     setSource(plurals) {
         if (typeof(plurals) !== 'object') return;
         this.source = plurals;
+    }
+
+    /**
+     * Return the array of source strings. This method is here
+     * for backwards compatilibity with the loctool plugins.
+     *
+     * @deprecated Use getSource() instead
+     * @returns {Array.<String>} the array of source strings
+     */
+    getSourcePlurals() {
+        return this.getSource();
+    }
+
+    /**
+     * Return the array of target strings. This method is here
+     * for backwards compatilibity with the loctool plugins.
+     *
+     * @deprecated Use getTarget() instead
+     * @returns {Array.<String>} the array of target strings
+     */
+    getTargetPlurals() {
+        return this.getTarget();
+    }
+
+    /**
+     * Return the array of source strings. This method is here
+     * for backwards compatilibity with the loctool plugins.
+     *
+     * @deprecated Use getSource() instead
+     * @returns {Array.<String>} the array of source strings
+     */
+    getSourceStrings() {
+        return this.getSource();
+    }
+
+    /**
+     * Return the array of target strings. This method is here
+     * for backwards compatilibity with the loctool plugins.
+     *
+     * @deprecated Use getTarget() instead
+     * @returns {Array.<String>} the array of target strings
+     */
+    getTargetStrings() {
+        return this.getTarget();
     }
 
     /**

--- a/src/ResourceString.js
+++ b/src/ResourceString.js
@@ -125,11 +125,12 @@ class ResourceString extends Resource {
      * @param {String} reskey the key of the string
      * @param {String} datatype the datatype of the string
      * @param {String} flavor the flavor of the string
+     * @param {String} context the context of the string
      * @static
      * @return {String} a hash key
      */
-    static hashKey(project, locale, reskey, datatype, flavor) {
-        const key = ["rs", project, locale, reskey, datatype, flavor].join("_");
+    static hashKey(project, locale, reskey, datatype, flavor, context) {
+        const key = ["rs", project, locale, reskey, datatype, flavor, context].join("_");
         logger.trace("Hashkey is " + key);
         return key;
     }
@@ -143,12 +144,13 @@ class ResourceString extends Resource {
      * @param {String} reskey the key of the string
      * @param {String} datatype the datatype of the string
      * @param {String} flavor the flavor of the string
+     * @param {String} context the context of the string
      * @static
      * @return {String} a hash key
      */
-    static cleanHashKey(project, locale, reskey, datatype, flavor) {
+    static cleanHashKey(project, locale, reskey, datatype, flavor, context) {
         const cleaned = reskey && reskey.replace(/\s+/g, " ").trim() || "";
-        const key = ["rs", project, locale, cleaned, datatype, flavor].join("_");
+        const key = ["rs", project, locale, cleaned, datatype, flavor, context].join("_");
         logger.trace("CleanHashkey is " + key);
         return key;
     }
@@ -160,7 +162,7 @@ class ResourceString extends Resource {
      */
     hashKey() {
         const locale = this.targetLocale || this.getSourceLocale();
-        return ResourceString.hashKey(this.project, locale, this.reskey, this.datatype, this.flavor);
+        return ResourceString.hashKey(this.project, locale, this.reskey, this.datatype, this.flavor, this.context);
     }
 
     /**
@@ -171,7 +173,7 @@ class ResourceString extends Resource {
      * @return {String} a unique hash key for this resource
      */
     hashKeyForTranslation(locale) {
-        return ResourceString.hashKey(this.project, locale, this.reskey, this.datatype, this.flavor);
+        return ResourceString.hashKey(this.project, locale, this.reskey, this.datatype, this.flavor, this.context);
     }
 
     /**
@@ -181,7 +183,7 @@ class ResourceString extends Resource {
      */
     cleanHashKey() {
         const locale = this.targetLocale || this.getSourceLocale();
-        return ResourceString.cleanHashKey(this.project, locale, this.reskey, this.datatype, this.flavor);
+        return ResourceString.cleanHashKey(this.project, locale, this.reskey, this.datatype, this.flavor, this.context);
     }
 
     /**
@@ -192,7 +194,7 @@ class ResourceString extends Resource {
      * @return {String} a unique hash key for this resource's string
      */
     cleanHashKeyForTranslation(locale) {
-        return ResourceString.cleanHashKey(this.project, locale, this.reskey, this.datatype, this.flavor);
+        return ResourceString.cleanHashKey(this.project, locale, this.reskey, this.datatype, this.flavor, this.context);
     }
 
     /**

--- a/test/testResourceArray.js
+++ b/test/testResourceArray.js
@@ -120,6 +120,29 @@ export const testResourceArray = {
         test.done();
     },
 
+    testResourceArrayConstructorBackwardsCompatible: function(test) {
+        test.expect(7);
+
+        const ra = new ResourceArray({
+            key: "asdf",
+            sourceArray: ["This is a test", "This is also a test", "This is not"],
+            sourceLocale: "en-US",
+            targetArray: ["Dies ist einen Test.", "Dies ist auch einen Test.", "Dies ist nicht."],
+            targetLocale: "de-DE",
+            pathName: "a/b/c.java"
+        });
+        test.ok(ra);
+
+        test.equal(ra.getKey(), "asdf");
+        test.deepEqual(ra.getSourceArray(), ["This is a test", "This is also a test", "This is not"]);
+        test.equal(ra.getSourceLocale(), "en-US");
+        test.deepEqual(ra.getTargetArray(), ["Dies ist einen Test.", "Dies ist auch einen Test.", "Dies ist nicht."]);
+        test.equal(ra.getTargetLocale(), "de-DE");
+        test.equal(ra.pathName, "a/b/c.java");
+
+        test.done();
+    },
+
     testResourceArrayConstructorDefaults: function(test) {
         test.expect(8);
 

--- a/test/testResourcePlural.js
+++ b/test/testResourcePlural.js
@@ -155,6 +155,49 @@ export const testResourcePlural = {
         test.done();
     },
 
+    testResourcePluralConstructorBackwardsCompatible: function(test) {
+        test.expect(7);
+
+        const rp = new ResourcePlural({
+            key: "asdf",
+            sourceLocale: "en-US",
+            pathName: "a/b/c.java",
+            sourceStrings: {
+                "one": "This is singular",
+                "two": "This is double",
+                "few": "This is the few case",
+                "many": "This is the many case"
+            },
+            targetLocale: "de-DE",
+            targetStrings: {
+                "one": "Dies ist einzigartig",
+                "two": "Dies ist doppelt",
+                "few": "Dies ist der wenige Fall",
+                "many": "Dies ist der viele Fall"
+            }
+        });
+        test.ok(rp);
+
+        test.equal(rp.getKey(), "asdf");
+        test.deepEqual(rp.getSourceStrings(), {
+            "one": "This is singular",
+            "two": "This is double",
+            "few": "This is the few case",
+            "many": "This is the many case"
+        });
+        test.equal(rp.getSourceLocale(), "en-US");
+        test.equal(rp.pathName, "a/b/c.java");
+        test.equal(rp.getTargetLocale(), "de-DE");
+        test.deepEqual(rp.getTargetStrings(), {
+            "one": "Dies ist einzigartig",
+            "two": "Dies ist doppelt",
+            "few": "Dies ist der wenige Fall",
+            "many": "Dies ist der viele Fall"
+        });
+
+        test.done();
+    },
+
     testResourcePluralConstructorDefaults: function(test) {
         test.expect(5);
 

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -557,7 +557,15 @@ export const testResourceString = {
     testResourceStringStaticHashKey: function(test) {
         test.expect(1);
 
-        test.equal(ResourceString.hashKey("iosapp", "de-DE", "This is a test", "html", "chocolate"), "rs_iosapp_de-DE_This is a test_html_chocolate");
+        test.equal(ResourceString.hashKey("iosapp", "de-DE", "This is a test", "html", "chocolate"), "rs_iosapp_de-DE_This is a test_html_chocolate_");
+
+        test.done();
+    },
+
+    testResourceStringStaticHashKeyWithContext: function(test) {
+        test.expect(1);
+
+        test.equal(ResourceString.hashKey("iosapp", "de-DE", "This is a test", "html", "chocolate", "context"), "rs_iosapp_de-DE_This is a test_html_chocolate_context");
 
         test.done();
     },
@@ -565,7 +573,7 @@ export const testResourceString = {
     testResourceStringStaticHashKeyMissingParts: function(test) {
         test.expect(1);
 
-        test.equal(ResourceString.hashKey(undefined, "de-DE", undefined, undefined), "rs__de-DE___");
+        test.equal(ResourceString.hashKey(undefined, "de-DE", undefined, undefined), "rs__de-DE____");
 
         test.done();
     },
@@ -585,7 +593,7 @@ export const testResourceString = {
         });
         test.ok(rs);
 
-        test.equal(rs.hashKey(), "rs_iosapp_de-DE_This is a test_html_");
+        test.equal(rs.hashKey(), "rs_iosapp_de-DE_This is a test_html__");
 
         test.done();
     },
@@ -606,7 +614,29 @@ export const testResourceString = {
         });
         test.ok(rs);
 
-        test.equal(rs.hashKey(), "rs_iosapp_de-DE_This is a test_html_chocolate");
+        test.equal(rs.hashKey(), "rs_iosapp_de-DE_This is a test_html_chocolate_");
+
+        test.done();
+    },
+
+    testResourceStringHashKeyWithFlavorAndContext: function(test) {
+        test.expect(2);
+
+        const rs = new ResourceString({
+            project: "iosapp",
+            key: "This is a test",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Dies ist einen Test.",
+            targetLocale: "de-DE",
+            pathName: "a/b/c.java",
+            datatype: "html",
+            flavor: "chocolate",
+            context: "context"
+        });
+        test.ok(rs);
+
+        test.equal(rs.hashKey(), "rs_iosapp_de-DE_This is a test_html_chocolate_context");
 
         test.done();
     },
@@ -624,7 +654,7 @@ export const testResourceString = {
         });
         test.ok(rs);
 
-        test.equal(rs.hashKey(), "rs_iosapp_en-US_This is a test_html_");
+        test.equal(rs.hashKey(), "rs_iosapp_en-US_This is a test_html__");
 
         test.done();
     },

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -21,7 +21,10 @@ const files = [
     "testResource.js",
     "testResourceString.js",
     "testResourceArray.js",
-    "testResourcePlural.js"
+    "testResourcePlural.js",
+    "testTranslationSet.js",
+    //"testResXliff.js",
+    //"testResXliff20.js"
 ];
 
 export default files;

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -22,7 +22,7 @@ const files = [
     "testResourceString.js",
     "testResourceArray.js",
     "testResourcePlural.js",
-    "testTranslationSet.js",
+    //"testTranslationSet.js",
     //"testResXliff.js",
     //"testResXliff20.js"
 ];


### PR DESCRIPTION
Current classes accept the `source` and `target` properties in the constructor, whereas the old classes in the loctool use `sourceArray`, `targetArray`, `sourcePlurals`, and `targetPlurals`. This change makes the constructor accept all of them so that these classes can be used with old code, but the `source` and `target` are the only ones that have getters and setters.