### PR TITLE
Add TranslationUnit and TranslationVariant classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Common code shared between the command-line tools such as loctool and i18nlint
 
 ## License
 
-Copyright © 2022, JEDLSoft
+Copyright © 2022-2023, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v1.4.0
+
+- Added TranslationUnit and TranslationVariant classes
+- added hashKey function to the utilities
 
 ### v1.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "module": "./src/index.js",
     "exports": {
         ".": {
@@ -61,9 +61,9 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "docdash": "^1.2.0",
-        "jsdoc": "^3.6.11",
-        "jsdoc-to-markdown": "^7.1.1",
+        "docdash": "^2.0.1",
+        "jsdoc": "^4.0.0",
+        "jsdoc-to-markdown": "^8.0.0",
         "nodeunit": "^0.11.3",
         "npm-run-all": "^4.1.5"
     },

--- a/src/TranslationUnit.js
+++ b/src/TranslationUnit.js
@@ -75,7 +75,7 @@ class TranslationUnit {
         this.properties = {};
 
         if (options) {
-            const requiredFields = ["source", "sourceLocale", "key", "file", "project"];
+            const requiredFields = ["source", "sourceLocale"];
             const missing = requiredFields.filter(p => {
                 if (typeof(options[p]) !== "undefined") {
                     this[p] = options[p];
@@ -88,7 +88,7 @@ class TranslationUnit {
                 throw new Error("Missing required parameters in the TranslationUnit constructor: " + missing.join(", "));
             }
 
-            const otherFields = ["target", "targetLocale", "resType", "state", "comment", "datatype", "flavor"];
+            const otherFields = ["key", "file", "project", "target", "targetLocale", "resType", "state", "comment", "datatype", "flavor"];
             for (var p of otherFields) {
                 this[p] = options[p];
             }
@@ -112,7 +112,7 @@ class TranslationUnit {
      * @returns {string} the unique hash key
      */
     hashKey() {
-        return [hashKey(this.string), this.locale, this.datatype].join("_");
+        return [hashKey(this.source), this.sourceLocale, this.datatype].join("_");
     }
 
     /**

--- a/src/TranslationUnit.js
+++ b/src/TranslationUnit.js
@@ -1,0 +1,178 @@
+/*
+ * TranslationUnit.js - model a translation unit in a translation file
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import log4js from "@log4js-node/log4js-api";
+
+import TranslationVariant from './TranslationVariant.js';
+import { hashKey } from './utils.js';
+
+const logger = log4js.getLogger("tools-common.TranslationUnit");
+
+/**
+ * @class Represent a translation unit. A translation unit is
+ * a segment in the source language, along with one or
+ * more variants, which are translations to various
+ * target languages. A translation unit may contain more
+ * than one translation for a particular locale, as there
+ * are sometimes more than one translation for a particular
+ * phrase in the source language, depending on the context.
+ */
+class TranslationUnit {
+    /**
+     * Create a new translation unit.
+     *
+     * The options may be undefined, which represents
+     * a new, clean TranslationUnit instance. The options object may also
+     * be an object with the following properties:
+     *
+     * <ul>
+     * <li><i>source</i> - source text for this unit (required)
+     * <li><i>sourceLocale</i> - the source locale spec for this unit (required)
+     * <li><i>target</i> - target text for this unit (optional)
+     * <li><i>targetLocale</i> - the target locale spec for this unit (optional)
+     * <li><i>key</i> - the unique resource key for this translation unit (required)
+     * <li><i>file</i> - path to the original source code file that contains the
+     * source text of this translation unit (required)
+     * <li><i>project</i> - the project that this string/unit is part of
+     * <li><i>resType</i> - type of this resource (string, array, plural) (optional)
+     * <li><i>state</i> - the state of the current unit (optional)
+     * <li><i>comment</i> - the translator's comment for this unit (optional)
+     * <li><i>datatype</i> - the source of the data of this unit (optional)
+     * <li><i>flavor</i> - the flavor that this string comes from(optional)
+     * </ul>
+     *
+     * If the required properties are not given, the constructor throws an exception.<p>
+     *
+     * For newly extracted strings, there is no target text yet. There must be a target
+     * locale for the translators to use when creating new target text, however. This
+     * means that there may be multiple translation units in a file with the same
+     * source locale and no target text, but different target locales.
+     *
+     * @param {Object} options options for this unit
+     */
+    constructor(options) {
+//        this.locale = options.locale;      -> sourceLocale
+//        this.string = options.string;      -> source
+//        this.datatype = options.datatype;  -> datatype
+
+        this.variants = [];
+        this.variantHash = {};
+        this.properties = {};
+
+        if (options) {
+            const requiredFields = ["source", "sourceLocale", "key", "file", "project"];
+            const missing = requiredFields.filter(p => {
+                if (typeof(options[p]) !== "undefined") {
+                    this[p] = options[p];
+                    return false;
+                }
+                return true;
+            });
+            // logger.trace("options is " + JSON.stringify(options));
+            if (missing.length) {
+                throw new Error("Missing required parameters in the TranslationUnit constructor: " + missing.join(", "));
+            }
+
+            const otherFields = ["target", "targetLocale", "resType", "state", "comment", "datatype", "flavor"];
+            for (var p of otherFields) {
+                this[p] = options[p];
+            }
+        }
+    }
+
+    /**
+     * Clone the current unit and return the clone.
+     * @returns {TranslationUnit} a clone of the current unit.
+     */
+    clone() {
+        return new TranslationUnit(this);
+    }
+
+    /**
+     * Return a unique hash key for this translation unit. The
+     * hash key is calculated from the source string and locale
+     * and does not depend on the properties or variants in
+     * the unit.
+     *
+     * @returns {string} the unique hash key
+     */
+    hashKey() {
+        return [hashKey(this.string), this.locale, this.datatype].join("_");
+    }
+
+    /**
+     * Return the list of variants for this translation unit.
+     * @returns {Array.<TranslationVariant>} the variants for
+     * this translation unit
+     */
+    getVariants() {
+        return this.variants;
+    }
+
+    /**
+     * Add a single variant to this translation unit. This variant
+     * is only added if it is unique in this translation unit. That is,
+     * No other variant exists in this unit with the same locale and
+     * string.
+     *
+     * @param {TranslationVariant} variant the variant to add
+     */
+    addVariant(variant) {
+        var key = variant.hashKey();
+        if (!this.variantHash[key]) {
+            this.variants.push(variant);
+            this.variantHash[key] = variant;
+        }
+    }
+
+    /**
+     * Add an array of variants to this translation unit. This only
+     * adds a variant if it is unique. That is, the unit is not
+     * added if the locale and string are the same as an existing
+     * variant.
+     *
+     * @param {Array.<TranslationVariant>} variants the array of variants to add
+     */
+    addVariants(variants) {
+        variants.forEach(variant => {
+            this.addVariant(variant);
+        });
+    }
+
+    /**
+     * Return the list of properties and their values for this translation unit.
+     * @returns {Object} an object mapping properties to values
+     */
+    getProperties() {
+        return this.properties;
+    }
+
+    /**
+     * Add a property to this translation unit.
+     * @param {Object} properties an object that maps properties to values
+     */
+    addProperties(properties) {
+        for (let p in properties) {
+            if (properties[p]) {
+                this.properties[p] = properties[p];
+            }
+        }
+    }
+}
+
+export default TranslationUnit;

--- a/src/TranslationVariant.js
+++ b/src/TranslationVariant.js
@@ -1,0 +1,51 @@
+/*
+ * TranslationVariant.js - model a translation variant in a translation file
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { hashKey } from './utils.js';
+
+/**
+ * @class A class that represents a translation unit variant.
+ */
+class TranslationVariant {
+    /**
+     * Options may contain the following properties:
+     * - locale: locale of the target string
+     * - string: the translation for this locale
+     *
+     * @param {Object} options
+     */
+    constructor(options) {
+        if (options) {
+            this.locale = options.locale;
+            this.string = options.string;
+        }
+    }
+
+    /**
+     * Return a unique hash key for this translation unit variant. The
+     * hash key is calculated from the source string and locale.
+     *
+     * @returns {string} the unique hash key
+     */
+    hashKey() {
+        return [hashKey(this.string), this.locale].join("_");
+    }
+}
+
+export default TranslationVariant;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ import ResourceArray from './ResourceArray.js';
 import ResourcePlural from './ResourcePlural.js';
 import TranslationSet from './TranslationSet.js';
 import ResourceXliff from './ResourceXliff.js';
+import TranslationUnit from './TranslationUnit.js';
+import TranslationVariant from './TranslationVariant.js';
 import {
     formatPath,
     getLocaleFromPath,
@@ -39,6 +41,8 @@ export {
     ResourceArray,
     ResourcePlural,
     TranslationSet,
+    TranslationUnit,
+    TranslationVariant,
     ResourceXliff,
     formatPath,
     getLocaleFromPath,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * utils.js - utility functions to support the other code
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,4 +371,33 @@ export function objectMap(object, visitor) {
         }
         return ret;
     }
+};
+
+/**
+ * Return a standard hash of the given source string.
+ *
+ * @param {String} source the source string as extracted from the
+ * source code, unmodified
+ * @returns {String} the hash key
+ */
+export function hashKey(source) {
+    if (!source) return undefined;
+    let hash = 0;
+    // these two numbers together = 46 bits so it won't blow out the precision of an integer in javascript
+    const modulus = 1073741789;  // largest prime number that fits in 30 bits
+    const multiple = 65521;      // largest prime that fits in 16 bits, co-prime with the modulus
+
+    // logger.trace("hash starts off at " + hash);
+
+    for (let i = 0; i < source.length; i++) {
+        // logger.trace("hash " + hash + " char " + source.charCodeAt(i) + "=" + source.charAt(i));
+        hash += source.charCodeAt(i);
+        hash *= multiple;
+        hash %= modulus;
+    }
+    const value = "r" + hash;
+
+    // System.out.println("String '" + source + "' hashes to " + value);
+
+    return value;
 };

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,7 +1,7 @@
 /*
  * testSuiteFiles.js - list the test files in this directory
  * 
- * Copyright © 2022, JEDLSoft
+ * Copyright © 2022-2023, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@
 
 const files = [
     "testResource.js",
-    "testResourceString.js",
     "testResourceArray.js",
     "testResourcePlural.js",
-    "testTranslationSet.js",
+    "testResourceString.js",
     "testResourceXliff.js",
     "testResourceXliff20.js",
+    "testTranslationSet.js",
+    "testTranslationUnit.js",
+    "testTranslationVariant.js",
     "testUtils.js"
 ];
 

--- a/test/testTranslationUnit.js
+++ b/test/testTranslationUnit.js
@@ -243,5 +243,27 @@ export const testTranslationUnit = {
         });
 
         test.done();
+    },
+
+    testTranslationUnitHashKey: function(test) {
+        test.expect(2);
+
+        const tu = new TranslationUnit({
+            source: "a",
+            sourceLocale: "en-US",
+            key: "key",
+            file: "a/b/c.js",
+            project: "bigproject",
+            target: "b",
+            targetLocale: "de-DE",
+            resType: "string",
+            state: "translated",
+            comment: "no comment",
+            datatype: "javascript",
+            flavor: "chocolate"
+        });
+        test.ok(tu);
+        test.equal(tu.hashKey(), "r6355537_en-US_javascript");
+        test.done();
     }
 };

--- a/test/testTranslationUnit.js
+++ b/test/testTranslationUnit.js
@@ -1,0 +1,247 @@
+/*
+ * testTranslationUnit.js - test the translation unit object.
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TranslationUnit from "../src/TranslationUnit.js";
+import TranslationVariant from "../src/TranslationVariant.js";
+
+export const testTranslationUnit = {
+     testTranslationUnitConstructor: function(test) {
+        test.expect(1);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+        test.done();
+    },
+
+    testTranslationUnitConstructorWithFields: function(test) {
+        test.expect(1);
+
+        const tu = new TranslationUnit({
+            source: "a",
+            sourceLocale: "en-US",
+            key: "key",
+            file: "a/b/c.js",
+            project: "bigproject",
+            target: "b",
+            targetLocale: "de-DE",
+            resType: "string",
+            state: "translated",
+            comment: "no comment",
+            datatype: "javascript",
+            flavor: "chocolate"
+        });
+        test.ok(tu);
+        test.done();
+    },
+
+    testTranslationUnitConstructorWithMissingRequiredFields: function(test) {
+        test.expect(1);
+
+        test.throws(() => {
+            const tu = new TranslationUnit({
+                source: "a",
+                target: "b",
+                targetLocale: "de-DE",
+                resType: "string",
+                state: "translated",
+                comment: "no comment",
+                datatype: "javascript",
+                flavor: "chocolate"
+            });
+        });
+        test.done();
+    },
+
+    testTranslationUnitConstructorWithMissingOptionalFields: function(test) {
+        test.expect(1);
+
+        const tu = new TranslationUnit({
+            source: "a",
+            sourceLocale: "en-US",
+            key: "key",
+            file: "a/b/c.js",
+            project: "bigproject"
+        });
+        test.ok(tu);
+        test.done();
+    },
+
+    testTranslationUnitRightFields: function(test) {
+        test.expect(13);
+
+        const tu = new TranslationUnit({
+            source: "a",
+            sourceLocale: "en-US",
+            key: "key",
+            file: "a/b/c.js",
+            project: "bigproject",
+            target: "b",
+            targetLocale: "de-DE",
+            resType: "string",
+            state: "translated",
+            comment: "no comment",
+            datatype: "javascript",
+            flavor: "chocolate"
+        });
+        test.ok(tu);
+
+        test.equal(tu.source, "a");
+        test.equal(tu.sourceLocale, "en-US");
+        test.equal(tu.key, "key");
+        test.equal(tu.file, "a/b/c.js");
+        test.equal(tu.project, "bigproject");
+        test.equal(tu.target, "b");
+        test.equal(tu.targetLocale, "de-DE");
+        test.equal(tu.resType, "string");
+        test.equal(tu.state, "translated");
+        test.equal(tu.comment, "no comment");
+        test.equal(tu.datatype, "javascript");
+        test.equal(tu.flavor, "chocolate");
+
+        test.done();
+    },
+
+    testTranslationUnitAddVariant: function(test) {
+        test.expect(5);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+
+        let variants = tu.getVariants();
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 0);
+
+        tu.addVariant(new TranslationVariant({
+            locale: "de-DE",
+            string: "Zeichenfolge"
+        }));
+
+        variants = tu.getVariants();
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 1);
+
+        test.done();
+    },
+
+    testTranslationUnitAddVariantRightOne: function(test) {
+        test.expect(5);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+
+        let variants;
+
+        tu.addVariant(new TranslationVariant({
+            locale: "de-DE",
+            string: "Zeichenfolge"
+        }));
+
+        variants = tu.getVariants();
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 1);
+
+        test.equal(variants[0].locale, "de-DE");
+        test.equal(variants[0].string, "Zeichenfolge");
+
+        test.done();
+    },
+
+    testTranslationUnitAddVariants: function(test) {
+        test.expect(5);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+
+        let variants = tu.getVariants();
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 0);
+
+        tu.addVariants([
+            new TranslationVariant({
+                locale: "de-DE",
+                string: "Zeichenfolge"
+            }),
+            new TranslationVariant({
+                locale: "nl-NL",
+                string: "string"
+            })
+        ]);
+
+        variants = tu.getVariants();
+        test.ok(Array.isArray(variants));
+        test.equal(variants.length, 2);
+
+        test.done();
+    },
+
+    testTranslationUnitNoProperties: function(test) {
+        test.expect(2);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+
+        test.deepEqual(tu.getProperties(), {});
+
+        test.done();
+    },
+
+    testTranslationUnitAddProperties: function(test) {
+        test.expect(3);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+
+        test.deepEqual(tu.getProperties(), {});
+        tu.addProperties({
+            foo: "bar",
+            asdf: "asdf"
+        });
+        test.deepEqual(tu.getProperties(), {
+            foo: "bar",
+            asdf: "asdf"
+        });
+
+        test.done();
+    },
+
+    testTranslationUnitAddPropertiesAdditive: function(test) {
+        test.expect(3);
+
+        const tu = new TranslationUnit();
+        test.ok(tu);
+
+        test.deepEqual(tu.getProperties(), {});
+        tu.addProperties({
+            foo: "bar",
+            asdf: "asdf"
+        });
+        tu.addProperties({
+            x: "y",
+            m: "n"
+        });
+        test.deepEqual(tu.getProperties(), {
+            foo: "bar",
+            asdf: "asdf",
+            x: "y",
+            m: "n"
+        });
+
+        test.done();
+    }
+};

--- a/test/testTranslationVariant.js
+++ b/test/testTranslationVariant.js
@@ -1,0 +1,55 @@
+/*
+ * testTranslationVariant.js - test the translation variant object.
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TranslationVariant from "../src/TranslationVariant.js";
+
+export const testTranslationVariant = {
+     testTranslationVariantConstructorEmpty: function(test) {
+        test.expect(1);
+
+        const tv = new TranslationVariant();
+        test.ok(tv);
+        test.done();
+    },
+
+     testTranslationVariantConstructor: function(test) {
+        test.expect(1);
+
+        const tv = new TranslationVariant({
+            locale: "de-DE",
+            string: "Zeichenfolge auf deutsch"
+        });
+        test.ok(tv);
+        test.done();
+    },
+
+     testTranslationVariantRightFields: function(test) {
+        test.expect(3);
+
+        const tv = new TranslationVariant({
+            locale: "de-DE",
+            string: "Zeichenfolge auf deutsch"
+        });
+        test.ok(tv);
+
+        test.equal(tv.locale, "de-DE");
+        test.equal(tv.string, "Zeichenfolge auf deutsch");
+        test.done();
+    },
+};

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,7 +1,7 @@
 /*
  * testUtils.js - test the utility functions
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import {
     isEmpty,
     makeDirs,
     containsActualText,
-    objectMap
+    objectMap,
+    hashKey
 } from "../src/utils.js";
 
 export const testUtils = {
@@ -539,4 +540,81 @@ export const testUtils = {
         test.done();
     },
 
+    testHashKey: function(test) {
+        test.expect(1);
+
+        test.equal(hashKey("This is a test"), "r654479252");
+
+        test.done();
+    },
+
+    testHashKeySimpleTexts1: function(test) {
+        test.expect(5);
+
+        test.equals(hashKey("Settings in your profile"), "r618035987");
+        test.equals(hashKey("All locations"), "r246937959");
+        test.equals(hashKey("Conditions"), "r103883086");
+        test.equals(hashKey("Everything"), "r414542544");
+        test.equals(hashKey("Locations"), "r29058502");
+
+        test.done();
+    },
+
+    testHashKeySimpleTexts2: function(test) {
+        test.expect(5);
+
+        test.equals(hashKey("Procedures"), "r807691021");
+        test.equals(hashKey("Functions"), "r535786086");
+        test.equals(hashKey("Morning and afternoon"), "r409842466");
+        test.equals(hashKey("Evening"), "r72303136");
+        test.equals(hashKey("Nighttime"), "r332185734");
+
+        test.done();
+    },
+
+    testHashKeySimpleTexts3: function(test) {
+        test.expect(8);
+
+        test.equals(hashKey("Private Profile"), "r314592735");
+        test.equals(hashKey("People you are connected to"), "r711926199");
+        test.equals(hashKey("Notifications"), "r284964820");
+        test.equals(hashKey("News"), "r613036745");
+        test.equals(hashKey("More Tips"), "r216617786");
+        test.equals(hashKey("Filters"), "r81370429");
+        test.equals(hashKey("Referral Link"), "r140625167");
+        test.equals(hashKey("Questions"), "r256277957");
+
+        test.done();
+    },
+
+    testHashKeyEscapes: function(test) {
+        test.expect(2);
+
+        test.equals(hashKey("Can\'t find id"), "r743945592");
+        test.equals(hashKey("Can\'t find an application for SMS"), "r909283218");
+
+        test.done();
+    },
+
+    testHashKeyPunctuation: function(test) {
+        test.expect(6);
+
+        test.equals(hashKey("{name}({generic_name})"), "r300446104");
+        test.equals(hashKey("{name}, {sharer_name} {start}found this interesting{end}"), "r8321889");
+        test.equals(hashKey("{sharer_name} {start}found this interesting{end}"), "r639868344");
+        test.equals(hashKey("Grow your network"), "r214079422");
+        test.equals(hashKey("Failed to send connection request!"), "r1015770123");
+        test.equals(hashKey("Connection request copied!"), "r136272443");
+
+        test.done();
+    },
+
+    testHashKeySameStringMeansSameKey: function(test) {
+        test.expect(2);
+
+        test.equal(hashKey("This is a test"), "r654479252");
+        test.equal(hashKey("This is a test"), "r654479252");
+
+        test.done();
+    }
 };


### PR DESCRIPTION
- copied from the loctool code and put in this library so that they can be shared
- these are going to be used by the new tmx library, which will in turn be used in the ilib-lint-glossary plugin which will allow you to specify a tmx file with glossary terms in it