### PR TITLE
Add isDirty() method to the resource classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.6.0
+
+- Added isDirty() method to the Resource class so we can see whether or
+  not the resource has been modified since it was first created
+    - also added clearDirty() method
+
 ### v1.5.0
 
 - Added getVariant method to the TranslationUnit class

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "module": "./src/index.js",
     "exports": {
         ".": {

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -462,6 +462,15 @@ class Resource {
     isDirty() {
         return this.dirty
     }
+
+    /**
+     * Clear the dirty flag. This is used for example when the Resource was
+     * written to disk and the modifications are already recorded, allowing
+     * new modifications later.
+     */
+    clearDirty() {
+        this.dirty = false;
+    }
 }
 
 export default Resource;

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -1,7 +1,7 @@
 /*
  * Resource.js - super class that represents a resource
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ class Resource {
 
         this.instances = [];
         this.pathName = this.pathName || "";
+        this.dirty = false;
     }
 
     /**
@@ -192,6 +193,7 @@ class Resource {
      */
     setSourceLocale(locale) {
         this.sourceLocale = locale || this.sourceLocale;
+        this.dirty = true;
     }
 
     /**
@@ -210,6 +212,7 @@ class Resource {
      */
     setTargetLocale(locale) {
         this.targetLocale = locale || this.targetLocale;
+        this.dirty = true;
     }
 
     /**
@@ -227,10 +230,11 @@ class Resource {
      * Set the project of this resource. This is a string that gives the
      * id of the project for this resource.
      *
-     * @param {Project} project the project to set for this resource
+     * @param {String} project the project name to set for this resource
      */
     setProject(project) {
-        this.project = project.getProjectId();
+        this.project = project;
+        this.dirty = true;
     }
 
     /**
@@ -242,6 +246,7 @@ class Resource {
      */
     setState(state) {
         this.state = validStates[state] ? state : this.state;
+        this.dirty = true;
     }
 
     /**
@@ -273,6 +278,7 @@ class Resource {
      */
     setComment(comment) {
         this.comment = comment;
+        this.dirty = true;
     }
 
     /**
@@ -416,6 +422,7 @@ class Resource {
             return false;
         }
         this.instances.push(resource);
+        this.dirty = true;
         return true;
     }
 
@@ -447,6 +454,13 @@ class Resource {
      */
     getInstances() {
         return this.instances;
+    }
+
+    /**
+     * Return true if this instance has been modified since its creation, and false otherwise.
+     */
+    isDirty() {
+        return this.dirty
     }
 }
 

--- a/src/ResourceArray.js
+++ b/src/ResourceArray.js
@@ -1,7 +1,7 @@
 /*
  * ResourceArray.js - represents an array of strings in a resource file
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ResourceArray.js
+++ b/src/ResourceArray.js
@@ -108,6 +108,7 @@ class ResourceArray extends Resource {
     setSource(arr) {
         if (!arr || !Array.isArray(arr)) return;
         this.source = arr;
+        this.dirty = true;
     }
 
     /**
@@ -119,6 +120,7 @@ class ResourceArray extends Resource {
     setTarget(arr) {
         if (!arr || !Array.isArray(arr)) return;
         this.target = arr;
+        this.dirty = true;
     }
 
     /**
@@ -181,6 +183,7 @@ class ResourceArray extends Resource {
         }
 
         this.source[i] = str;
+        this.dirty = true;
     }
 
     /**
@@ -200,6 +203,7 @@ class ResourceArray extends Resource {
         }
 
         this.target[i] = str;
+        this.dirty = true;
     }
 
     /**

--- a/src/ResourcePlural.js
+++ b/src/ResourcePlural.js
@@ -1,7 +1,7 @@
 /*
  * ResourcePlural.js - represents an array of plural strings in a resource file
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ResourcePlural.js
+++ b/src/ResourcePlural.js
@@ -94,6 +94,7 @@ class ResourcePlural extends Resource {
     setSource(plurals) {
         if (typeof(plurals) !== 'object') return;
         this.source = plurals;
+        this.dirty = true;
     }
 
     /**
@@ -148,6 +149,7 @@ class ResourcePlural extends Resource {
     setTarget(plurals) {
         if (typeof(plurals) !== 'object') return;
         this.target = plurals;
+        this.dirty = true;
     }
 
     /**
@@ -217,6 +219,7 @@ class ResourcePlural extends Resource {
             this.source = {};
         }
         this.source[pluralCategory] = str;
+        this.dirty = true;
     }
 
     /**
@@ -234,6 +237,7 @@ class ResourcePlural extends Resource {
             this.target = {};
         }
         this.target[pluralCategory] = str;
+        this.dirty = true;
     }
 
     /**

--- a/src/ResourceString.js
+++ b/src/ResourceString.js
@@ -1,7 +1,7 @@
 /*
  * ResourceString.js - represents an string in a resource file
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ResourceString.js
+++ b/src/ResourceString.js
@@ -31,16 +31,16 @@ const logger = log4js.getLogger("tools-common.ResourceString");
  */
 class ResourceString extends Resource {
     /**
-	 * Construct a new ResourceString instance. The props may contain any
-	 * of properties from the Resource constructor and additionally,
-	 * these properties:
-	 *
-	 * <ul>
-	 * <li>source {String} - the source string associated with this key
-	 * </ul>
-	 *
-	 * @constructor
-	 * @param {Object} props properties of the string, as defined above
+     * Construct a new ResourceString instance. The props may contain any
+     * of properties from the Resource constructor and additionally,
+     * these properties:
+     *
+     * <ul>
+     * <li>source {String} - the source string associated with this key
+     * </ul>
+     *
+     * @constructor
+     * @param {Object} props properties of the string, as defined above
      */
     constructor(props) {
         super(props);
@@ -65,6 +65,7 @@ class ResourceString extends Resource {
     setSource(str) {
         if (typeof(str) !== 'string') return;
         this.source = str;
+        this.dirty = true;
     }
 
     /**
@@ -75,6 +76,7 @@ class ResourceString extends Resource {
     setTarget(str) {
         if (typeof(str) !== 'string') return;
         this.target = str;
+        this.dirty = true;
     }
 
     /**

--- a/test/testResource.js
+++ b/test/testResource.js
@@ -738,4 +738,260 @@ export const testResource = {
         test.done();
     },
 
+    testResourceSetSourceLocale: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getSourceLocale(), "en-US");
+
+        rs.setSourceLocale("de-DE");
+
+        test.equal(rs.getSourceLocale(), "de-DE");
+        test.done();
+    },
+
+    testResourceSetSourceLocaleIsDirty: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isDirty())
+
+        rs.setSourceLocale("de-DE");
+
+        test.ok(rs.isDirty());
+        test.done();
+    },
+
+    testResourceSetTargetLocale: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getTargetLocale(), "ja-JP");
+
+        rs.setTargetLocale("de-DE");
+
+        test.equal(rs.getTargetLocale(), "de-DE");
+        test.done();
+    },
+
+    testResourceSetTargetLocaleIsDirty: function(test) {
+        test.expect(2);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isDirty())
+
+        rs.setTargetLocale("de-DE");
+
+        test.ok(rs.isDirty());
+        test.done();
+    },
+
+    testResourceSetState: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md",
+            state: "new"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getState(), "new");
+
+        rs.setState("translated");
+
+        test.equal(rs.getState(), "translated");
+        test.done();
+    },
+
+    testResourceSetTargetLocaleIsDirty: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md",
+            state: "new"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isDirty())
+
+        rs.setState("translated");
+
+        test.ok(rs.isDirty());
+        test.done();
+    },
+
+    testResourceSetProject: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md",
+            state: "new"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getProject(), "foo");
+
+        rs.setProject("asdf");
+
+        test.equal(rs.getProject(), "asdf");
+        test.done();
+    },
+
+    testResourceSetProjectIsDirty: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md",
+            state: "new"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isDirty())
+
+        rs.setState("asdf");
+
+        test.ok(rs.isDirty());
+        test.done();
+    },
+
+    testResourceSetComment: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md",
+            state: "new",
+            comment: "comment"
+        });
+        test.ok(rs);
+
+        test.equal(rs.getComment(), "comment");
+
+        rs.setComment("other");
+
+        test.equal(rs.getComment(), "other");
+        test.done();
+    },
+
+    testResourceSetCommentIsDirty: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md",
+            state: "new"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isDirty())
+
+        rs.setComment("asdf");
+
+        test.ok(rs.isDirty());
+        test.done();
+    }
 };

--- a/test/testResource.js
+++ b/test/testResource.js
@@ -1,7 +1,7 @@
 /*
  * testResource.js - test the base resource object
  *
- * Copyright © 202, JEDLSoft
+ * Copyright © 2022-2023, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testResource.js
+++ b/test/testResource.js
@@ -1017,7 +1017,7 @@ export const testResource = {
         rs.setSourceLocale("de-DE");
 
         test.ok(rs.isDirty());
-        
+
         rs.clearDirty();
 
         test.ok(!rs.isDirty());

--- a/test/testResource.js
+++ b/test/testResource.js
@@ -993,5 +993,36 @@ export const testResource = {
 
         test.ok(rs.isDirty());
         test.done();
-    }
+    },
+
+    testResourceClearDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            pathName: "a/b/c.md"
+        });
+        test.ok(rs);
+
+        test.ok(!rs.isDirty())
+
+        rs.setSourceLocale("de-DE");
+
+        test.ok(rs.isDirty());
+        
+        rs.clearDirty();
+
+        test.ok(!rs.isDirty());
+
+        test.done();
+    },
+
 };

--- a/test/testResourceArray.js
+++ b/test/testResourceArray.js
@@ -1,7 +1,7 @@
 /*
  * testResourceArray.js - test the resource array object.
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testResourceArray.js
+++ b/test/testResourceArray.js
@@ -483,6 +483,30 @@ export const testResourceArray = {
         test.done();
     },
 
+    testResourceArrayAddSourceStringIsDirty: function(test) {
+        test.expect(4);
+
+        const ra = new ResourceArray({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "de-DE",
+            key: "asdf",
+            source: ["This is a test", "This is also a test", "This is not"],
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted"
+        });
+        test.ok(ra);
+
+        test.ok(!ra.isDirty());
+        ra.addSourceItem(3, "This is the third one")
+
+        test.equal(ra.getSourceItem(3), "This is the third one");
+        test.ok(ra.isDirty());
+
+        test.done();
+    },
+
     testResourceArrayAddTargetString: function(test) {
         test.expect(2);
 
@@ -503,6 +527,32 @@ export const testResourceArray = {
         ra.addTargetItem(3, "This is the third one")
 
         test.equal(ra.getTargetItem(3), "This is the third one");
+
+        test.done();
+    },
+
+    testResourceArrayAddTargetStringIsDirty: function(test) {
+        test.expect(4);
+
+        const ra = new ResourceArray({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "de-DE",
+            key: "asdf",
+            source: ["This is a test", "This is also a test", "This is not"],
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            target: ["Dies ist einen Test.", "Dies ist auch einen Test.", "Dies ist nicht."],
+            targetLocale: "de-DE"
+        });
+        test.ok(ra);
+
+        test.ok(!ra.isDirty());
+        ra.addTargetItem(3, "This is the third one")
+
+        test.equal(ra.getTargetItem(3), "This is the third one");
+        test.ok(ra.isDirty());
 
         test.done();
     },
@@ -1171,6 +1221,110 @@ export const testResourceArray = {
         test.ok(dup);
 
         test.ok(!rs.isInstance(dup));
+
+        test.done();
+    },
+
+    testResourceArraySetSource: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: ["a b c", "b", "c"],
+            target: ["a b c", "b", "c"]
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getSource(), ["a b c", "b", "c"]);
+        rs.setSource(["x", "y", "z"]);
+        test.deepEqual(rs.getSource(), ["x", "y", "z"]);
+
+        test.done();
+    },
+
+    testResourceArraySetSourceIsDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: ["a b c", "b", "c"],
+            target: ["a b c", "b", "c"]
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getSource(), ["a b c", "b", "c"]);
+        test.ok(!rs.isDirty());
+
+        rs.setSource(["x", "y", "z"]);
+        test.ok(rs.isDirty());
+
+        test.done();
+    },
+
+    testResourceArraySetTarget: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: ["a b c", "b", "c"],
+            target: ["a b c", "b", "c"]
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getTarget(), ["a b c", "b", "c"]);
+        rs.setTarget(["x", "y", "z"]);
+        test.deepEqual(rs.getTarget(), ["x", "y", "z"]);
+
+        test.done();
+    },
+
+    testResourceArraySetTargetIsDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourceArray({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: ["a b c", "b", "c"],
+            target: ["a b c", "b", "c"]
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getTarget(), ["a b c", "b", "c"]);
+        test.ok(!rs.isDirty());
+
+        rs.setTarget(["x", "y", "z"]);
+        test.ok(rs.isDirty());
 
         test.done();
     }

--- a/test/testResourcePlural.js
+++ b/test/testResourcePlural.js
@@ -544,6 +544,37 @@ export const testResourcePlural = {
         test.done();
     },
 
+    testResourcePluralAddSourceIsDirty: function(test) {
+        test.expect(5);
+
+        const rp = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "de-DE",
+            key: "asdf",
+            source: {
+                "one": "This is singular",
+                "two": "This is double",
+                "few": "This is the few case",
+                "many": "This is the many case"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted"
+        });
+        test.ok(rp);
+
+        test.ok(!rp.getSourcePlural("zero"));
+        test.ok(!rp.isDirty());
+
+        rp.addSourcePlural("zero", "This is the zero one")
+
+        test.equal(rp.getSourcePlural("zero"), "This is the zero one");
+        test.ok(rp.isDirty());
+
+        test.done();
+    },
+
     testResourcePluralAddSourceReplace: function(test) {
         test.expect(3);
 
@@ -767,6 +798,44 @@ export const testResourcePlural = {
         rp.addTargetPlural("zero", "This is the zero one")
 
         test.equal(rp.getTargetPlural("zero"), "This is the zero one");
+
+        test.done();
+    },
+
+    testResourcePluralAddTargetIsDirty: function(test) {
+        test.expect(5);
+
+        const rp = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "de-DE",
+            key: "asdf",
+            source: {
+                "one": "This is singular",
+                "two": "This is double",
+                "few": "This is the few case",
+                "many": "This is the many case"
+            },
+            targetLocale: "de-DE",
+            target: {
+                "one": "Dies ist einzigartig",
+                "two": "Dies ist doppelt",
+                "few": "Dies ist der wenige Fall",
+                "many": "Dies ist der viele Fall"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted"
+        });
+        test.ok(rp);
+
+        test.ok(!rp.isDirty());
+        test.ok(!rp.getTargetPlural("zero"));
+
+        rp.addTargetPlural("zero", "This is the zero one")
+
+        test.equal(rp.getTargetPlural("zero"), "This is the zero one");
+        test.ok(rp.isDirty());
 
         test.done();
     },
@@ -1419,5 +1488,110 @@ export const testResourcePlural = {
         test.ok(!rs.isInstance(dup));
 
         test.done();
+    },
+
+    testResourcePluralSetSource: function(test) {
+        test.expect(3);
+
+        const rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: { one: "singular", other: "plural" },
+            target: { one: "singular", other: "plural" }
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getSource(), { one: "singular", other: "plural" });
+        rs.setSource({ one: "x", other: "y" });
+        test.deepEqual(rs.getSource(), { one: "x", other: "y" });
+
+        test.done();
+    },
+
+    testResourcePluralSetSourceIsDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: { one: "singular", other: "plural" },
+            target: { one: "singular", other: "plural" }
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getSource(), { one: "singular", other: "plural" });
+        test.ok(!rs.isDirty());
+
+        rs.setSource({ one: "x", other: "y" });
+        test.ok(rs.isDirty());
+
+        test.done();
+    },
+
+    testResourcePluralSetTarget: function(test) {
+        test.expect(3);
+
+        const rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: { one: "singular", other: "plural" },
+            target: { one: "singular", other: "plural" }
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getTarget(), { one: "singular", other: "plural" });
+        rs.setTarget({ one: "x", other: "y" });
+        test.deepEqual(rs.getTarget(), { one: "x", other: "y" });
+
+        test.done();
+    },
+
+    testResourcePluralSetTargetIsDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourcePlural({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: { one: "singular", other: "plural" },
+            target: { one: "singular", other: "plural" }
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getTarget(), { one: "singular", other: "plural" });
+        test.ok(!rs.isDirty());
+
+        rs.setTarget({ one: "x", other: "y" });
+        test.ok(rs.isDirty());
+
+        test.done();
     }
+
 };

--- a/test/testResourcePlural.js
+++ b/test/testResourcePlural.js
@@ -1,7 +1,7 @@
 /*
  * testResourcePlural.js - test the resource plural object.
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -765,5 +765,110 @@ export const testResourceString = {
         test.ok(!rs.isInstance(dup));
 
         test.done();
+    },
+
+    testResourceStringSetSource: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "source string",
+            target: "target string"
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getSource(), "source string");
+        rs.setSource("other source");
+        test.deepEqual(rs.getSource(), "other source");
+
+        test.done();
+    },
+
+    testResourceStringSetSourceIsDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "source string",
+            target: "target string"
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getSource(), "source string");
+        test.ok(!rs.isDirty());
+
+        rs.setSource("other source");
+        test.ok(rs.isDirty());
+
+        test.done();
+    },
+
+    testResourceStringSetTarget: function(test) {
+        test.expect(3);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "source string",
+            target: "target string"
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getTarget(), "target string");
+        rs.setTarget("other target");
+        test.deepEqual(rs.getTarget(), "other target");
+
+        test.done();
+    },
+
+    testResourceStringSetTargetIsDirty: function(test) {
+        test.expect(4);
+
+        const rs = new ResourceString({
+            context: "a",
+            datatype: "markdown",
+            dnt: false,
+            flavor: "asdf",
+            project: "foo",
+            reskey: "test.string",
+            resType: "string",
+            sourceLocale: "en-US",
+            targetLocale: "ja-JP",
+            source: "source string",
+            target: "target string"
+        });
+        test.ok(rs);
+
+        test.deepEqual(rs.getTarget(), "target string");
+        test.ok(!rs.isDirty());
+
+        rs.setTarget("other target");
+        test.ok(rs.isDirty());
+
+        test.done();
     }
+
 };

--- a/test/testResourceString.js
+++ b/test/testResourceString.js
@@ -1,7 +1,7 @@
 /*
  * testResourceString.js - test the resource string object.
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- made sure every place that sets something into the resource sets the dirty flag
- will be needed when we do the auto-correction in the linter so we can tell if any of the Resource instances have been modified by an auto-correction, and therefore whether or not we need to write the file out again afterwards