### PR TITLE
Add getLines() and location information to the ResourceXliff

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.7.0
+
+- added support for location information of the start of each resource
+  in the original file where the resource instances were read from
+    - supports line and character within the line
+
 ### v1.6.0
 
 - Added isDirty() method to the Resource class so we can see whether or

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ limitations under the License.
 
 ### v1.7.0
 
+- added getLines() method to tell how many lines there are in the xml file
 - added support for location information of the start of each resource
   in the original file where the resource instances were read from
     - supports line and character within the line

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
         "@log4js-node/log4js-api": "^1.0.2",
         "ilib-ctype": "^1.1.0",
         "ilib-locale": "^1.2.2",
-        "ilib-xliff": "^1.1.0",
-        "ilib-xml-js": "^1.7.0"
+        "ilib-xliff": "^1.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "module": "./src/index.js",
     "exports": {
         ".": {
@@ -72,6 +72,7 @@
         "@log4js-node/log4js-api": "^1.0.2",
         "ilib-ctype": "^1.1.0",
         "ilib-locale": "^1.2.2",
-        "ilib-xliff": "^1.0.0"
+        "ilib-xliff": "^1.1.0",
+        "ilib-xml-js": "^1.7.0"
     }
 }

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -92,6 +92,7 @@ class Resource {
             this.localize = typeof(props.localize) === "boolean" ? props.localize : true; // some files have resources we do not want to localize/translate
             this.flavor = props.flavor;
             this.index = props.index;
+            this.location = props.location; // optional location of the transunits in the xml file
         }
 
         this.instances = [];
@@ -470,6 +471,18 @@ class Resource {
      */
     clearDirty() {
         this.dirty = false;
+    }
+
+    /**
+     * Return the location of the resource instance in the original file where it was read
+     * from. This is usually an object containing a line and a char property which gives the
+     * line number and character within that line where the representation of the resource
+     * instance starts.
+     *
+     * @returns {Object<{line, char}>} the location information
+     */
+    getLocation() {
+        return this.location;
     }
 }
 

--- a/src/ResourceXliff.js
+++ b/src/ResourceXliff.js
@@ -248,7 +248,8 @@ class ResourceXliff {
                 resType: tu.resType,
                 datatype: tu.datatype,
                 state: tu.state,
-                flavor: tu.flavor
+                flavor: tu.flavor,
+                location: tu.location
             });
 
             if (tu.target) {
@@ -273,7 +274,8 @@ class ResourceXliff {
                 resType: tu.resType,
                 datatype: tu.datatype,
                 state: tu.state,
-                flavor: tu.flavor
+                flavor: tu.flavor,
+                location: tu.location
             });
 
             if (tu.target) {
@@ -298,7 +300,8 @@ class ResourceXliff {
                 resType: tu.resType,
                 datatype: tu.datatype,
                 state: tu.state,
-                flavor: tu.flavor
+                flavor: tu.flavor,
+                location: tu.location
             });
 
             if (tu.target) {

--- a/src/ResourceXliff.js
+++ b/src/ResourceXliff.js
@@ -1,7 +1,7 @@
 /*
  * Xliff.js - convert an Xliff file into a set of resources and vice versa
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -433,10 +433,28 @@ class ResourceXliff {
         return this.xliff.serialize(true);
     }
 
+    /**
+     * Return the number of lines in the xml representation of this file.
+     *
+     * @returns {Number} the number of lines in the xml
+     */
+    getLines() {
+        return this.xliff.getLines();
+    }
+
+    /**
+     * Return the number of resources in this resource xliff file.
+     * @returns {Number} the number of resources in this file
+     */
     size() {
         return this.ts.size();
     }
 
+    /**
+     * Get the version number of this file. Currently, it only supports
+     * xliff v1.2 and v2.0.
+     * @returns {String} the version number of the file
+     */
     getVersion() {
         return this.version;
     }

--- a/test/testResourceXliff.js
+++ b/test/testResourceXliff.js
@@ -1,7 +1,7 @@
 /*
  * testXliff.js - test the Xliff object.
  *
- * Copyright © 2016-2017, 2019-2022 HealthTap, Inc. and JEDLSoft
+ * Copyright © 2016-2017, 2019-2023 HealthTap, Inc. and JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1259,6 +1259,71 @@ export const testResourceXliff = {
         test.equal(reslist[1].getId(), "2");
         test.equal(reslist[1].getTarget(), "bebe bebe");
         test.equal(reslist[1].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testResourceXliffParseGetLines: function(test) {
+        test.expect(2);
+
+        const x = new ResourceXliff();
+        test.ok(x);
+
+        x.parse(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.equal(x.getLines(), 19);
+
+        test.done();
+    },
+
+    testResourceXliffParseGetSize: function(test) {
+        test.expect(2);
+
+        const x = new ResourceXliff();
+        test.ok(x);
+
+        x.parse(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // only 2 resources result from all the above
+        test.equal(x.size(), 2);
 
         test.done();
     },

--- a/test/testResourceXliff20.js
+++ b/test/testResourceXliff20.js
@@ -1,7 +1,7 @@
 /*
  * testXliff20.js - test the Xliff 2.0 object.
  *
- * Copyright © 2019,2021 JEDLSoft
+ * Copyright © 2019,2021,2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1252,6 +1252,70 @@ export const testResourceXliff20 = {
         test.equal(reslist[1].getTarget(), "bebe bebe");
         test.equal(reslist[1].getTargetLocale(), "de-DE");
 
+        test.done();
+    },
+
+    testXliff20ParseGetLines: function(test) {
+        test.expect(2);
+
+        var x = new ResourceXliff();
+        test.ok(x);
+
+        x.parse(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+
+        test.equal(x.getLines(), 19);
+        test.done();
+    },
+
+    testXliff20ParseSize: function(test) {
+        test.expect(2);
+
+        var x = new ResourceXliff();
+        test.ok(x);
+
+        x.parse(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+
+        test.equal(x.size(), 2);
         test.done();
     },
 


### PR DESCRIPTION
- add getLines() to tell how many lines there are in the xml of the file
- added optional location information into the Resource instance
    - for Resource instances from an xliff, it can be filled in via the xliff library
- bumped version v1.6.0 -> v1.7.0 for the new features
- CI/CD will fail until the ilib-xml-js package is published and the new version of ilib-xliff is published