### PR TITLE
Export HTML data from the Utils namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,11 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: circleci/node:14-browsers
+          docker_image: cimg/node:14.21-browsers
       - test:
-          docker_image: circleci/node:16-browsers
+          docker_image: cimg/node:16.20-browsers
+      - test:
+          docker_image: cimg/node:18.9-browsers
+      - test:
+          docker_image: cimg/node:20.9-browsers
       - test

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.9.0
+
+- added data about HTML in the Utils
+    - nonBreakingTags - a hash of all HTML tags that do not break a string
+    - selfClosingTags - a hash of all HTML tags that are commonly self-closing
+    - ignoreTags - a hash of HTML tags where the content is ignored, such as <script>
+    - localizableAttributes - a hash of all tags that contain attributes which
+      have localizable values
+
 ### v1.8.1
 
 - update dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "module": "./src/index.js",
     "exports": {
         ".": {
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@log4js-node/log4js-api": "^1.0.2",
-        "ilib-ctype": "^1.1.0",
+        "ilib-ctype": "^1.2.0",
         "ilib-locale": "^1.2.2",
         "ilib-xliff": "^1.1.0"
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -436,3 +436,100 @@ export function hashKey(source) {
 
     return value;
 };
+
+/**
+ * A hash containing a list of HTML tags that do not
+ * cause a break in a resource string. These tags should
+ * be included in the middle of the string.
+ */
+export const nonBreakingTags = {
+    "a": true,
+    "abbr": true,
+    "b": true,
+    "bdi": true,
+    "bdo": true,
+    "br": true,
+    "dfn": true,
+    "del": true,
+    "em": true,
+    "i": true,
+    "ins": true,
+    "mark": true,
+    "ruby": true,
+    "rt": true,
+    "span": true,
+    "strong": true,
+    "sub": true,
+    "sup": true,
+    "time": true,
+    "u": true,
+    "var": true,
+    "wbr": true
+};
+
+/**
+ * A hash containing a list of HTML tags that are
+ * typically self-closing. That is, in HTML4 and earlier,
+ * the close tag was not needed for these.
+ */
+export const selfClosingTags = {
+    "area": true,
+    "base": true,
+    "bdi": true,
+    "bdo": true,
+    "br": true,
+    "embed": true,
+    "hr": true,
+    "img": true,
+    "input": true,
+    "link": true,
+    "option": true,
+    "param": true,
+    "source": true,
+    "track": true
+};
+
+/**
+ * A hash containing a list of HTML tags where
+ * the text content inside of those tags should be
+ * ignored for localization purposes. Instead,
+ * those contents should just be copied to the
+ * localized file unmodified.
+ */
+export const ignoreTags = {
+    "code": true,
+    "output": true,
+    "samp": true,
+    "script": true,
+    "style": true
+};
+
+/**
+ * List of html5 tags and their attributes that contain localizable strings.
+ * The "*" indicates it applies to the given attributes on every tag.
+ * Also added ARIA attributes to localize for accessibility. For more details,
+ * see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
+ */
+export const localizableAttributes = {
+    "area": {"alt":true},
+    "img": {"alt":true},
+    "input": {
+        "alt": true,
+        "placeholder": true
+    },
+    "optgroup": {"label":true},
+    "option": {"label":true},
+    "textarea": {"placeholder":true},
+    "track": {"label":true},
+    "*": {
+        "title": true,
+        "aria-braillelabel": true,
+        "aria-brailleroledescription": true,
+        "aria-description": true,
+        "aria-label": true,
+        "aria-placeholder": true,
+        "aria-roledescription": true,
+        "aria-rowindextext": true,
+        "aria-valuetext": true
+    }
+};

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -28,7 +28,11 @@ import {
     makeDirs,
     containsActualText,
     objectMap,
-    hashKey
+    hashKey,
+    nonBreakingTags,
+    selfClosingTags,
+    ignoreTags,
+    localizableAttributes
 } from "../src/utils.js";
 
 /**
@@ -554,5 +558,21 @@ describe("testUtils", () => {
         makeDirs("./testfiles/testdir");
         expect(fs.existsSync("./testfiles/testdir")).toBeTruthy();
         rmr("./testfiles/testdir");
+    });
+
+    test("that the HTML data is exported properly", () => {
+        expect.assertions(8);
+
+        expect(nonBreakingTags.a).toBe(true);
+        expect(nonBreakingTags.abbr).toBe(true);
+
+        expect(selfClosingTags.area).toBe(true);
+        expect(selfClosingTags.base).toBe(true);
+
+        expect(ignoreTags.code).toBe(true);
+        expect(ignoreTags.output).toBe(true);
+
+        expect(localizableAttributes.area.alt).toBe(true);
+        expect(localizableAttributes["*"]["aria-label"]).toBe(true);
     });
 });


### PR DESCRIPTION
- this helps with HTML parsing and linting
- data original extracted from loctool and shared here for multiple tools to use it