### PR TITLE
Support commonjs as well as ESM versions of this package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parameters:
         docker_image:
           type: string
-          default: cimg/node:current-browsers
+          default: cimg/node:current
     docker:
       - image: << parameters.docker_image >>
     steps:
@@ -26,11 +26,13 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: cimg/node:14.21-browsers
+          docker_image: cimg/node:12.13
       - test:
-          docker_image: cimg/node:16.20-browsers
+          docker_image: cimg/node:14.21
       - test:
-          docker_image: cimg/node:18.9-browsers
+          docker_image: cimg/node:16.19
       - test:
-          docker_image: cimg/node:20.9-browsers
+          docker_image: cimg/node:18.9
+      - test:
+          docker_image: cimg/node:20.9
       - test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,74 @@
+/**
+ * Gruntfile.js - build this project
+ *
+ * @license
+ * Copyright © 2024, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function(grunt) {
+    require('load-grunt-tasks')(grunt);
+
+    var debug = grunt.option('mode') === 'dev';
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        uglify: {
+            options: {
+                banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
+            },
+            build: {
+                src: 'src/*.js',
+                dest: 'lib/'
+            }
+        },
+        babel: {
+            options: {
+                sourceMap: true,
+                presets: [[
+                    '@babel/preset-env',
+                    {
+                        targets: {
+                            node: "10",
+                            browsers: "cover 99.5%"
+                        }
+                    }
+                ]],
+                compact: !debug,
+                minified: !debug
+            },
+            dist: {
+                files: [{
+                    expand: true,
+                    cwd: 'src',
+                    src: ['*.js'],
+                    dest: 'lib/',
+                    ext: '.js'
+                }]
+            }
+        },
+        clean: {
+            dist: ['lib']
+        }
+    });
+
+    // Load the plugin that provides the "uglify" task.
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+
+    // Default task(s).
+    grunt.registerTask('default', ['babel']);
+    if (!debug) grunt.registerTask('uglify', ['uglify']);
+};

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ limitations under the License.
 ### v1.10.0
 
 - now ships with commonjs code as well as modern ESM in the same package
+- updated dependencies
 
 ### v1.9.1
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Common code shared between the command-line tools such as loctool and i18nlint
 
 ## License
 
-Copyright © 2022-2023, JEDLSoft
+Copyright © 2022-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v1.10.0
+
+- now ships with commonjs code as well as modern ESM in the same package
 
 ### v1.9.1
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+    "presets": [[
+      "@babel/preset-env", {
+         "targets": {
+            "node": "current",
+            "browsers": "cover 99.5%"
+         }
+      }
+   ]],
+   "plugins": ["add-module-exports"]
+};

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.9.1",
+    "version": "1.10.0",
     "module": "./src/index.js",
     "exports": {
         ".": {
-            "import": "./src/index.js"
+            "import": "./src/index.js",
+            "require": "./lib/index.js"
         }
     },
-    "type": "module",
     "description": "Library of common classes and functions for the ilib command-line tools",
     "keywords": [
         "internationalization",
@@ -52,19 +52,37 @@
         "node": ">=10.0.0"
     },
     "scripts": {
-        "dist": "npm-run-all doc ; npm pack",
-        "test": "LANG=en_US.UTF8 node --experimental-vm-modules ./node_modules/.bin/jest",
-        "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules ./node_modules/.bin/jest --watch",
-        "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/.bin/jest -i",
-        "clean": "git clean -f -d src test",
+        "build": "npm run build:prod",
+        "build:prod": "grunt babel --mode=prod",
+        "build:dev": "grunt babel --mode=dev",
+        "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "dist": "npm-run-all doc build:prod build:pkg; npm pack",
+        "test": "LANG=en_US.UTF8  npm run build:dev ; node --experimental-vm-modules ./node_modules/.bin/jest --testEnvironment node",
+        "test:watch": "LANG=en_US.UTF8  npm run build:dev ; node --experimental-vm-modules ./node_modules/.bin/jest --testEnvironment node --watch",
+        "debug": "LANG=en_US.UTF8  npm run build:dev ; node --experimental-vm-modules --inspect-brk node_modules/.bin/jest --testEnvironment node -i",
+        "clean": "git clean -f -d src test; rm -rf lib",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/ilibToolsCommon.md ; npm run doc:html",
-        "doc:html": "jsdoc -c jsdoc.json"
+        "doc:html": "jsdoc -c jsdoc.json",
+        "prepare": "conditional-install"
     },
     "devDependencies": {
+        "@babel/core": "^7.23.5",
+        "@babel/preset-env": "^7.23.5",
+        "@babel/register": "^7.22.15",
+        "@babel/runtime": "^7.23.5",
+        "babel-loader": "^8.3.0",
+        "babel-plugin-add-module-exports": "^1.0.4",
+        "conditional-install": "^1.0.1",
         "docdash": "^2.0.2",
-        "jest": "^29.7.0",
+        "grunt": "^1.6.1",
+        "grunt-babel": "^8.0.0",
+        "grunt-cli": "^1.4.3",
+        "grunt-contrib-clean": "^2.0.1",
+        "grunt-contrib-jshint": "^3.2.0",
+        "grunt-contrib-uglify": "^5.2.2",
         "jsdoc": "^4.0.2",
         "jsdoc-to-markdown": "^8.0.0",
+        "load-grunt-tasks": "^5.1.0",
         "npm-run-all": "^4.1.5",
         "semver": "^7.5.4"
     },
@@ -73,5 +91,13 @@
         "ilib-ctype": "^1.2.0",
         "ilib-locale": "^1.2.2",
         "ilib-xliff": "^1.1.0"
+    },
+    "conditionalDependencies": {
+        "process.versions.node < 14.0.0": {
+            "jest": "^26.0.0"
+        },
+        "process.versions.node >= 14.0.0": {
+            "jest": "^29.0.0"
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     ],
     "files": [
         "src",
+        "lib",
         "docs",
         "README.md",
         "LICENSE"

--- a/package.json
+++ b/package.json
@@ -66,11 +66,11 @@
         "prepare": "conditional-install"
     },
     "devDependencies": {
-        "@babel/core": "^7.23.5",
-        "@babel/preset-env": "^7.23.5",
-        "@babel/register": "^7.22.15",
-        "@babel/runtime": "^7.23.5",
-        "babel-loader": "^8.3.0",
+        "@babel/core": "^7.24.5",
+        "@babel/preset-env": "^7.24.5",
+        "@babel/register": "^7.23.7",
+        "@babel/runtime": "^7.24.5",
+        "babel-loader": "^9.1.3",
         "babel-plugin-add-module-exports": "^1.0.4",
         "conditional-install": "^1.0.1",
         "docdash": "^2.0.2",
@@ -80,15 +80,15 @@
         "grunt-contrib-clean": "^2.0.1",
         "grunt-contrib-jshint": "^3.2.0",
         "grunt-contrib-uglify": "^5.2.2",
-        "jsdoc": "^4.0.2",
-        "jsdoc-to-markdown": "^8.0.0",
+        "jsdoc": "^4.0.3",
+        "jsdoc-to-markdown": "^8.0.1",
         "load-grunt-tasks": "^5.1.0",
         "npm-run-all": "^4.1.5",
-        "semver": "^7.5.4"
+        "semver": "^7.6.2"
     },
     "dependencies": {
         "@log4js-node/log4js-api": "^1.0.2",
-        "ilib-ctype": "^1.2.0",
+        "ilib-ctype": "^1.2.1",
         "ilib-locale": "^1.2.2",
         "ilib-xliff": "^1.1.0"
     },

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}


### PR DESCRIPTION
This package is needed by some of the loctool plugins (like the new ilib-loctool-tap-i18n) which are all old commonjs code (for now), so this package needs to support loading as commonjs or ESM.