### PR TITLE
Add and support file location information in resources and translation units

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.11.0
+
+- added location information to the TranslationUnit and Resource constructors
+  plus a Location class to keep track of the location in the source file
+  where the resources come from.
+
 ### v1.10.0
 
 - now ships with commonjs code as well as modern ESM in the same package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tools-common",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "module": "./src/index.js",
     "exports": {
         ".": {

--- a/src/Location.js
+++ b/src/Location.js
@@ -1,0 +1,59 @@
+/*
+ * Location.js - Location information for a resource
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class Represents the location of a resource in a file
+ */
+class Location {
+    /**
+     * Construct a new Location instance. A location should have either an offset from
+     * the beginning of the file, or a line & character number. The first line of the
+     * file is considered line 0, and the first character in a line is character 0.
+     *
+     * @constructor
+     * @param {Object} info location info of the resource
+     * @param {Number?} info.offset offset of the first character of the resource
+     * relative to the beginning of the file
+     * @param {Number?} info.line line number of the resource
+     * @param {Number?} info.char character number of the resource
+     */
+    constructor(info) {
+        this.info = {
+        };
+
+        if (info) {
+            if (info.offset) {
+                this.info.offset = parseInt(info.offset);
+            }
+            if (info.line) {
+                this.info.line = parseInt(info.line);
+                this.info.char = parseInt(info.char);
+            }
+        }
+    }
+
+    /**
+     * Return the location information
+     */
+    getLocation() {
+        return this.info;
+    }
+}
+
+export default Location;

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -1,7 +1,7 @@
 /*
  * Resource.js - super class that represents a resource
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,13 @@ class Resource {
      * <li>pathName {String} - pathName to the file where the string was extracted from
      * <li>autoKey {boolean} - true if the key was generated based on the source text
      * <li>state {String} - current state of the resource (ie. "new", "translated", or "accepted")
+     * <li>id {String} - the id of the current resource
+     * <li>comment {String} - the comment (translator's note) of this resource
+     * <li>dnt {boolean} - Do not translate this resource when this is set to true. Default: false
+     * <li>datatype {String} - the type of file that this resource came from
+     * <li>flavor {String} - the "flavor" of this string, if any. (Android)
+     * <li>location {Location} - the location in the file given in pathName where this this resource
+     * is located
      * </ul>
      *
      * @constructor
@@ -479,10 +486,11 @@ class Resource {
      * line number and character within that line where the representation of the resource
      * instance starts.
      *
-     * @returns {Object<{line, char}>} the location information
+     * @returns {Location|undefined} the location information, or undefined if no location
+     * information is available
      */
     getLocation() {
-        return this.location;
+        return this.location?.getLocation();
     }
 }
 

--- a/src/ResourceXliff.js
+++ b/src/ResourceXliff.js
@@ -24,6 +24,8 @@ import ResourceString from './ResourceString.js';
 import ResourceArray from './ResourceArray.js';
 import ResourcePlural from './ResourcePlural.js';
 import TranslationSet from './TranslationSet.js';
+import Location from './Location.js';
+
 import { isEmpty } from './utils.js';
 
 const logger = log4js.getLogger("tools-common.ResourceXliff");
@@ -129,7 +131,8 @@ class ResourceXliff {
                     comment: res.comment,
                     resType: res.resType,
                     datatype: res.datatype,
-                    flavor: res.getFlavor ? res.getFlavor() : undefined
+                    flavor: res.getFlavor ? res.getFlavor() : undefined,
+                    location: res.getLocation()
                 });
                 units.push(tu);
                 break;
@@ -152,7 +155,8 @@ class ResourceXliff {
                     comment: res.comment,
                     resType: res.resType,
                     datatype: res.datatype,
-                    flavor: res.getFlavor ? res.getFlavor() : undefined
+                    flavor: res.getFlavor ? res.getFlavor() : undefined,
+                    location: res.getLocation()
                 });
 
                 for (let j = 0; j < sarr.length; j++) {
@@ -188,7 +192,8 @@ class ResourceXliff {
                     context: res.context,
                     resType: res.resType,
                     datatype: res.datatype,
-                    flavor: res.getFlavor ? res.getFlavor() : undefined
+                    flavor: res.getFlavor ? res.getFlavor() : undefined,
+                    location: res.getLocation()
                 });
 
                 const sp = res.getSource();
@@ -249,7 +254,7 @@ class ResourceXliff {
                 datatype: tu.datatype,
                 state: tu.state,
                 flavor: tu.flavor,
-                location: tu.location
+                location: new Location(tu.location)
             });
 
             if (tu.target) {
@@ -275,7 +280,7 @@ class ResourceXliff {
                 datatype: tu.datatype,
                 state: tu.state,
                 flavor: tu.flavor,
-                location: tu.location
+                location: new Location(tu.location)
             });
 
             if (tu.target) {
@@ -301,7 +306,7 @@ class ResourceXliff {
                 datatype: tu.datatype,
                 state: tu.state,
                 flavor: tu.flavor,
-                location: tu.location
+                location: new Location(tu.location)
             });
 
             if (tu.target) {
@@ -392,7 +397,6 @@ class ResourceXliff {
         if (this.ts.size() > 0) {
             // first convert the resources into translation units
             let resources = this.ts.getAll();
-            let tu;
 
             if (this.allowDups) {
                 // only look at the initial set of resources

--- a/src/TranslationUnit.js
+++ b/src/TranslationUnit.js
@@ -1,7 +1,7 @@
 /*
  * TranslationUnit.js - model a translation unit in a translation file
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,8 @@ class TranslationUnit {
      * <li><i>state</i> - the state of the current unit (optional)
      * <li><i>comment</i> - the translator's comment for this unit (optional)
      * <li><i>datatype</i> - the source of the data of this unit (optional)
-     * <li><i>flavor</i> - the flavor that this string comes from(optional)
+     * <li><i>flavor</i> - the flavor that this string comes from (optional)
+     * <li><i>location</i> - the location information where this string is encoded in the file
      * </ul>
      *
      * If the required properties are not given, the constructor throws an exception.<p>
@@ -88,7 +89,7 @@ class TranslationUnit {
                 throw new Error("Missing required parameters in the TranslationUnit constructor: " + missing.join(", "));
             }
 
-            const otherFields = ["key", "file", "project", "target", "targetLocale", "resType", "state", "comment", "datatype", "flavor"];
+            const otherFields = ["key", "file", "project", "target", "targetLocale", "resType", "state", "comment", "datatype", "flavor", "location"];
             for (var p of otherFields) {
                 this[p] = options[p];
             }

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import TranslationSet from './TranslationSet.js';
 import ResourceXliff from './ResourceXliff.js';
 import TranslationUnit from './TranslationUnit.js';
 import TranslationVariant from './TranslationVariant.js';
+import Location from './Location.js';
 import {
     formatPath,
     parsePath,
@@ -62,5 +63,6 @@ export {
     nonBreakingTags,
     selfClosingTags,
     ignoreTags,
-    localizableAttributes
+    localizableAttributes,
+    Location
 };

--- a/test/Location.test.js
+++ b/test/Location.test.js
@@ -1,0 +1,110 @@
+/*
+ * Location.test.js - test the location class
+ *
+ * Copyright © 2024, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Location from "../src/Location.js";
+
+describe("testLocation", () => {
+    test("with empty constructor", () => {
+        expect.assertions(1);
+
+        const loc = new Location();
+        expect(loc).toBeTruthy();
+    });
+
+    test("with offset location only", () => {
+        expect.assertions(2);
+
+        const loc = new Location({
+            offset: 34
+        });
+        expect(loc).toBeTruthy();
+
+        expect(loc.getLocation()).toStrictEqual({
+            offset: 34
+        });
+    });
+
+    test("with line and char location only", () => {
+        expect.assertions(2);
+
+        const loc = new Location({
+            line: 4,
+            char: 3
+        });
+        expect(loc).toBeTruthy();
+
+        expect(loc.getLocation()).toStrictEqual({
+            line: 4,
+            char: 3
+        });
+    });
+
+    test("with offset and line and char location together", () => {
+        expect.assertions(2);
+
+        const loc = new Location({
+            offset: 43,
+            line: 4,
+            char: 3
+        });
+        expect(loc).toBeTruthy();
+
+        expect(loc.getLocation()).toStrictEqual({
+            offset: 43,
+            line: 4,
+            char: 3
+        });
+    });
+
+    test("with strings instead of numbers", () => {
+        expect.assertions(2);
+
+        const loc = new Location({
+            offset: "43",
+            line: "4",
+            char: "3"
+        });
+        expect(loc).toBeTruthy();
+
+        expect(loc.getLocation()).toStrictEqual({
+            offset: 43,
+            line: 4,
+            char: 3
+        });
+    });
+
+    test("ignoring extraneous options", () => {
+        expect.assertions(2);
+
+        const loc = new Location({
+            offset: 43,
+            line: 4,
+            char: 3,
+            foo: 34,
+            bar: 1234
+        });
+        expect(loc).toBeTruthy();
+
+        expect(loc.getLocation()).toStrictEqual({
+            offset: 43,
+            line: 4,
+            char: 3
+        });
+    });
+});

--- a/test/ResourceXliff.test.js
+++ b/test/ResourceXliff.test.js
@@ -1097,7 +1097,7 @@ describe("testResourceXliff", () => {
     });
 
     test("ResourceXliffParseWithSourceOnly", () => {
-        expect.assertions(21);
+        expect.assertions(23);
 
         const x = new ResourceXliff();
         expect(x).toBeTruthy();
@@ -1136,6 +1136,10 @@ describe("testResourceXliff", () => {
         expect(reslist[0].getProject()).toBe("androidapp");
         expect(reslist[0].resType).toBe("string");
         expect(reslist[0].getId()).toBe("1");
+        expect(reslist[0].getLocation()).toStrictEqual({
+            line: 4,
+            char: 7
+        });
 
         expect(reslist[1].getSource()).toBe("baby baby");
         expect(reslist[1].getSourceLocale()).toBe("en-US");
@@ -1146,10 +1150,14 @@ describe("testResourceXliff", () => {
         expect(reslist[1].getProject()).toBe("webapp");
         expect(reslist[1].resType).toBe("string");
         expect(reslist[1].getId()).toBe("2");
+        expect(reslist[1].getLocation()).toStrictEqual({
+            line: 11,
+            char: 7
+        });
     });
 
     test("ResourceXliffParseWithSourceAndTarget", () => {
-        expect.assertions(21);
+        expect.assertions(23);
 
         const x = new ResourceXliff();
         expect(x).toBeTruthy();
@@ -1192,6 +1200,10 @@ describe("testResourceXliff", () => {
         expect(reslist[0].getId()).toBe("1");
         expect(reslist[0].getTarget()).toBe("foobarfoo");
         expect(reslist[0].getTargetLocale()).toBe("de-DE");
+        expect(reslist[0].getLocation()).toStrictEqual({
+            line: 4,
+            char: 7
+        });
 
         expect(reslist[1].getSource()).toBe("baby baby");
         expect(reslist[1].getSourceLocale()).toBe("en-US");
@@ -1202,6 +1214,10 @@ describe("testResourceXliff", () => {
         expect(reslist[1].getId()).toBe("2");
         expect(reslist[1].getTarget()).toBe("bebe bebe");
         expect(reslist[1].getTargetLocale()).toBe("fr-FR");
+        expect(reslist[1].getLocation()).toStrictEqual({
+            line: 12,
+            char: 7
+        });
     });
 
     test("ResourceXliffParseGetLines", () => {
@@ -1462,7 +1478,7 @@ describe("testResourceXliff", () => {
     });
 
     test("ResourceXliffParseWithPlurals", () => {
-        expect.assertions(10);
+        expect.assertions(11);
 
         const x = new ResourceXliff();
         expect(x).toBeTruthy();
@@ -1502,6 +1518,10 @@ describe("testResourceXliff", () => {
         expect(reslist[0].getProject()).toBe("androidapp");
         expect(reslist[0].resType).toBe("plural");
         expect(reslist[0].getId()).toBe("1");
+        expect(reslist[0].getLocation()).toStrictEqual({
+            line: 4,
+            char: 7
+        });
     });
 
     test("ResourceXliffParseWithPluralsTranslated", () => {
@@ -1557,7 +1577,7 @@ describe("testResourceXliff", () => {
     });
 
     test("ResourceXliffParseWithArrays", () => {
-        expect.assertions(10);
+        expect.assertions(11);
 
         const x = new ResourceXliff();
         expect(x).toBeTruthy();
@@ -1593,6 +1613,10 @@ describe("testResourceXliff", () => {
         expect(reslist[0].getProject()).toBe("androidapp");
         expect(reslist[0].resType).toBe("array");
         expect(!reslist[0].getTargetArray()).toBeTruthy();
+        expect(reslist[0].getLocation()).toStrictEqual({
+            line: 4,
+            char: 7
+        });
     });
 
     test("ResourceXliffParseWithArraysTranslated", () => {

--- a/test/ResourceXliff20.test.js
+++ b/test/ResourceXliff20.test.js
@@ -1086,7 +1086,7 @@ describe("testResourceXliff20", () => {
     });
 
     test("Xliff20ParseWithSourceOnly", () => {
-        expect.assertions(21);
+        expect.assertions(23);
 
         var x = new ResourceXliff();
         expect(x).toBeTruthy();
@@ -1126,6 +1126,10 @@ describe("testResourceXliff20", () => {
         expect(reslist[0].getProject()).toBe("androidapp");
         expect(reslist[0].resType).toBe("string");
         expect(reslist[0].getId()).toBe("1");
+        expect(reslist[0].getLocation()).toStrictEqual({
+            line: 4,
+            char: 5
+        });
 
         expect(reslist[1].getSource()).toBe("baby baby");
         expect(reslist[1].getSourceLocale()).toBe("en-US");
@@ -1136,10 +1140,14 @@ describe("testResourceXliff20", () => {
         expect(reslist[1].getProject()).toBe("webapp");
         expect(reslist[1].resType).toBe("string");
         expect(reslist[1].getId()).toBe("2");
+        expect(reslist[1].getLocation()).toStrictEqual({
+            line: 11,
+            char: 5
+        });
     });
 
     test("Xliff20ParseWithSourceAndTarget", () => {
-        expect.assertions(21);
+        expect.assertions(23);
 
         var x = new ResourceXliff();
         expect(x).toBeTruthy();
@@ -1182,6 +1190,10 @@ describe("testResourceXliff20", () => {
         expect(reslist[0].getId()).toBe("1");
         expect(reslist[0].getTarget()).toBe("foobarfoo");
         expect(reslist[0].getTargetLocale()).toBe("de-DE");
+        expect(reslist[0].getLocation()).toStrictEqual({
+            line: 3,
+            char: 5
+        });
 
         expect(reslist[1].getSource()).toBe("baby baby");
         expect(reslist[1].getSourceLocale()).toBe("en-US");
@@ -1192,6 +1204,10 @@ describe("testResourceXliff20", () => {
         expect(reslist[1].getId()).toBe("2");
         expect(reslist[1].getTarget()).toBe("bebe bebe");
         expect(reslist[1].getTargetLocale()).toBe("de-DE");
+        expect(reslist[1].getLocation()).toStrictEqual({
+            line: 11,
+            char: 5
+        });
     });
 
     test("Xliff20ParseGetLines", () => {

--- a/test/TranslationUnit.test.js
+++ b/test/TranslationUnit.test.js
@@ -78,7 +78,7 @@ describe("testTranslationUnit", () => {
     });
 
     test("TranslationUnitRightFields", () => {
-        expect.assertions(13);
+        expect.assertions(14);
 
         const tu = new TranslationUnit({
             source: "a",
@@ -92,7 +92,12 @@ describe("testTranslationUnit", () => {
             state: "translated",
             comment: "no comment",
             datatype: "javascript",
-            flavor: "chocolate"
+            flavor: "chocolate",
+            location: {
+                offset: 23,
+                line: 3,
+                char: 12
+            }
         });
         expect(tu).toBeTruthy();
 
@@ -108,6 +113,11 @@ describe("testTranslationUnit", () => {
         expect(tu.comment).toBe("no comment");
         expect(tu.datatype).toBe("javascript");
         expect(tu.flavor).toBe("chocolate");
+        expect(tu.location).toStrictEqual({
+            offset: 23,
+            line: 3,
+            char: 12
+        });
     });
 
     test("TranslationUnitAddVariant", () => {


### PR DESCRIPTION
- Refers to location information of resources or translation units in a file, which is either by offset or by line & character numbers
- Support was half way there already in resources. This PR solidifies that support by:
    - adding unit tests and verifying that it works as expected
    - making the constructors support the location field
    - creating a Location class to clarify what a location should contain and to validate the parameters
 - Add support for transferring the location information from translation units to resources and back again in the ResourceXliff class