### PR TITLE
Update ilib-xliff to version supporting inline elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "@log4js-node/log4js-api": "^1.0.2",
         "ilib-ctype": "^1.2.1",
         "ilib-locale": "^1.2.2",
-        "ilib-xliff": "^1.1.0"
+        "ilib-xliff": "^1.2.0"
     },
     "conditionalDependencies": {
         "process.versions.node < 14.0.0": {

--- a/test/ResourceXliff.test.js
+++ b/test/ResourceXliff.test.js
@@ -2089,7 +2089,7 @@ describe("testResourceXliff", () => {
         expect(reslist[0].getProject()).toBe("webapp");
         expect(reslist[0].resType).toBe("string");
         expect(reslist[0].getId()).toBe("2");
-
+            // it should preserve whitespace between inline elements
         expect(reslist[0].getTarget()).toBe("This is segment 1. This is segment 2. This is segment 3.");
         expect(reslist[0].getTargetLocale()).toBe("fr-FR");
     });
@@ -2125,8 +2125,8 @@ describe("testResourceXliff", () => {
         expect(reslist[0].getProject()).toBe("webapp");
         expect(reslist[0].resType).toBe("string");
         expect(reslist[0].getId()).toBe("2");
-
-        expect(reslist[0].getTarget()).toBe("This is segment 1.This is segment 2.This is segment 3.");
+        // it should preserve whitespace between inline elements
+        expect(reslist[0].getTarget()).toBe("This is segment 1. This is segment 2. This is segment 3.");
         expect(reslist[0].getTargetLocale()).toBe("zh-Hans-CN");
     });
 


### PR DESCRIPTION
See https://github.com/iLib-js/xliff/pull/5

* Bumped package dependency to latest ilib-xliff
* Updated tests for whitespace between mrk segments to match ilib-xliff fixed behaviour